### PR TITLE
Fix docs url

### DIFF
--- a/src/localstack-dind/devcontainer-template.json
+++ b/src/localstack-dind/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "localstack-dind",
-    "version": "0.1.0",
+    "version": "0.1.1",
     "name": "LocalStack Docker-in-Docker",
     "description": "A template to manage LocalStack in DinD via CLI",
     "documentationURL": "https://github.com/localstack/devcontainer-template/tree/main/src/localstack-dind",

--- a/src/localstack-dind/devcontainer-template.json
+++ b/src/localstack-dind/devcontainer-template.json
@@ -3,7 +3,7 @@
     "version": "0.1.0",
     "name": "LocalStack Docker-in-Docker",
     "description": "A template to manage LocalStack in DinD via CLI",
-    "documentationURL": "https://github.com/localstack/devcontainer-template/tree/main/src/localstack",
+    "documentationURL": "https://github.com/localstack/devcontainer-template/tree/main/src/localstack-dind",
     "licenseURL": "https://github.com/localstack/devcontainer-template/blob/main/LICENSE",
     "options": {
         "imageVariant": {

--- a/src/localstack-dood/devcontainer-template.json
+++ b/src/localstack-dood/devcontainer-template.json
@@ -3,7 +3,7 @@
     "version": "0.1.1",
     "name": "LocalStack Docker-outside-of-Docker",
     "description": "A template to manage LocalStack in DooD",
-    "documentationURL": "https://github.com/localstack/devcontainer-template/tree/main/src/localstack",
+    "documentationURL": "https://github.com/localstack/devcontainer-template/tree/main/src/localstack-dood",
     "licenseURL": "https://github.com/localstack/devcontainer-template/blob/main/LICENSE",
     "options": {
         "imageVariant": {

--- a/src/localstack-dood/devcontainer-template.json
+++ b/src/localstack-dood/devcontainer-template.json
@@ -1,6 +1,6 @@
 {
     "id": "localstack-dood",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "name": "LocalStack Docker-outside-of-Docker",
     "description": "A template to manage LocalStack in DooD",
     "documentationURL": "https://github.com/localstack/devcontainer-template/tree/main/src/localstack-dood",


### PR DESCRIPTION
# Motivation
We've noticed that the URLs on the templates page is off.

# Changes
- change docs URL
- bump up version